### PR TITLE
panels.py: fix argument 2 has unexpected type 'float'

### DIFF
--- a/Panels/panels.py
+++ b/Panels/panels.py
@@ -220,7 +220,7 @@ class LeftPanel ( wx.Panel ):
         self.m_chain = wx.dataview.TreeListCtrl( self, wx.ID_ANY, wx.DefaultPosition, wx.Size( -1,-1 ), wx.dataview.TL_DEFAULT_STYLE|wx.dataview.TL_MULTIPLE )
         self.m_chain.SetMinSize( wx.Size( 80,-1 ) )
 
-        self.m_chain.AppendColumn( u"Properties", size[0] / 2, wx.ALIGN_LEFT, wx.COL_RESIZABLE )
+        self.m_chain.AppendColumn( u"Properties", int(size[0] / 2), wx.ALIGN_LEFT, wx.COL_RESIZABLE )
         self.m_chain.AppendColumn( u"*", 24, wx.ALIGN_LEFT, 0 )
         self.m_chain.AppendColumn( u"Values", wx.COL_WIDTH_DEFAULT, wx.ALIGN_LEFT, wx.COL_RESIZABLE )
 


### PR DESCRIPTION
Crashed with python 3.11.4,

```bash
Traceback (most recent call last):
  File "/home/vowstar/Projects/2023/jtagGUI/main.py", line 12, in <module>
    MainWindow.Mywin(None,'JTAG Viewer', parser=bsdl_parser) 
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vowstar/Projects/2023/jtagGUI/Panels/MainWindow.py", line 49, in __init__
    self.leftP = LeftPanel(splitV)
                 ^^^^^^^^^^^^^^^^^
  File "/home/vowstar/Projects/2023/jtagGUI/Panels/LeftPanel.py", line 11, in __init__
    panels.LeftPanel.__init__(self, parent)
  File "/home/vowstar/Projects/2023/jtagGUI/Panels/panels.py", line 223, in __init__
    self.m_chain.AppendColumn( u"Properties", size[0] / 2, wx.ALIGN_LEFT, wx.COL_RESIZABLE )
TypeError: TreeListCtrl.AppendColumn(): argument 2 has unexpected type 'float'
```

The argument 2 of self.m_chain.AppendColumn function only allow int.